### PR TITLE
Fixed up issue where "create" imported records for updates

### DIFF
--- a/app/services/nfg_csv_importer/import_service.rb
+++ b/app/services/nfg_csv_importer/import_service.rb
@@ -173,6 +173,8 @@ class NfgCsvImporter::ImportService
       return
     end
 
+    was_new_record = model_obj.new_record?
+
     begin
       saved_object = model_obj.save
     rescue => e
@@ -206,7 +208,7 @@ class NfgCsvImporter::ImportService
       imported_for_id: imported_for.id,
       importable: importable,
       transaction_id: transaction_id,
-      action: get_action(importable),
+      action: (was_new_record ? 'create' : 'update'),
       row_data: row
     )
   end
@@ -227,14 +229,6 @@ class NfgCsvImporter::ImportService
 
   def spreadsheet
     @spreadsheet ||= open_spreadsheet
-  end
-
-  def get_action(record)
-    if record.new_record? || record.previous_changes["id"].present?
-      "create"
-    else
-      "update"
-    end
   end
 
   def all_headers_are_string_type?

--- a/app/services/nfg_csv_importer/import_service.rb
+++ b/app/services/nfg_csv_importer/import_service.rb
@@ -206,9 +206,9 @@ class NfgCsvImporter::ImportService
       imported_for_id: imported_for.id,
       importable: importable,
       transaction_id: transaction_id,
-      action: get_action(model_obj),
+      action: get_action(importable),
       row_data: row
-    )
+    ) if importable.previous_changes.any?
   end
 
   def open_spreadsheet

--- a/app/services/nfg_csv_importer/import_service.rb
+++ b/app/services/nfg_csv_importer/import_service.rb
@@ -208,7 +208,7 @@ class NfgCsvImporter::ImportService
       transaction_id: transaction_id,
       action: get_action(importable),
       row_data: row
-    ) if importable.previous_changes.any?
+    )
   end
 
   def open_spreadsheet

--- a/app/services/nfg_csv_importer/import_service.rb
+++ b/app/services/nfg_csv_importer/import_service.rb
@@ -173,8 +173,6 @@ class NfgCsvImporter::ImportService
       return
     end
 
-    was_new_record = model_obj.new_record?
-
     begin
       saved_object = model_obj.save
     rescue => e
@@ -208,7 +206,7 @@ class NfgCsvImporter::ImportService
       imported_for_id: imported_for.id,
       importable: importable,
       transaction_id: transaction_id,
-      action: (was_new_record ? 'create' : 'update'),
+      action: get_action(importable),
       row_data: row
     )
   end
@@ -229,6 +227,14 @@ class NfgCsvImporter::ImportService
 
   def spreadsheet
     @spreadsheet ||= open_spreadsheet
+  end
+
+  def get_action(record)
+    if record.previous_changes[:id] || record.created_at >= 1.minute.ago
+      "create"
+    else
+      "update"
+    end
   end
 
   def all_headers_are_string_type?


### PR DESCRIPTION
While working on DM-3497 (specifically adding activity feed items when contacts/donations are added and updated via import) I found that nfg_csv_importer_imported_records weren't being created quite right.  Updates were being added as creates.