### PR TITLE
Clear onboarding_session_id when cancelling an import

### DIFF
--- a/app/controllers/nfg_csv_importer/onboarding/import_data_controller.rb
+++ b/app/controllers/nfg_csv_importer/onboarding/import_data_controller.rb
@@ -41,6 +41,14 @@ module NfgCsvImporter
         [:finish]
       end
 
+      # on before show steps
+      def file_origination_type_selection_on_before_show
+        # clear onboarder session when cancelling an import
+        # This can be called using:
+        # = link_to 'Cancel', wizard_path(:file_origination_type_selection, reset_import: true)
+        reset_onboarding_session if params[:reset_import] == 'true'
+      end
+
       # on before save steps
       def file_origination_type_selection_on_before_save
         # you can add logic here to perform, such as appending data to the params, before the form is to be saved
@@ -81,7 +89,7 @@ module NfgCsvImporter
       end
 
       def finish_on_valid_step
-        session[:onboarding_session_id] = nil # wipe out the session so we can work an another import
+        reset_onboarding_session # wipe out the session so we can work an another import
       end
 
       def preview_confirmation_on_valid_step
@@ -160,7 +168,7 @@ module NfgCsvImporter
       def finish_wizard_path
         # since this should only be called when the user is leaving the last step
         # in case they left the finish step without actually finishing
-        session[:onboarding_session_id] = nil # wipe out the session so we can work an another import
+        reset_onboarding_session # wipe out the session so we can work an another import
 
         imports_path
          # where to take the user when the have finished this step
@@ -240,6 +248,10 @@ module NfgCsvImporter
         # We can skip the import_type step if the admin only have access
         # to a single import definition.
         self.steps -= [:import_type] if import_definitions.size == 1
+      end
+
+      def reset_onboarding_session
+        session[:onboarding_session_id] = nil
       end
     end
   end

--- a/spec/controllers/import_data_controller_spec.rb
+++ b/spec/controllers/import_data_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe NfgCsvImporter::Onboarding::ImportDataController do
+
+  let(:params) { { params: { use_route: :nfg_csv_importer, reset_import: reset_import, id: step } } }
+  let(:step) { 'file_origination_type_selection' }
+  let(:session_id) { 'some-id' }
+  render_views
+
+  describe "#show" do
+    subject { get :show, params }
+
+    let(:reset_import) { true }
+
+    before do
+      # when new session is created, assign a mock id for ease of testing
+      ::Onboarding::Session.any_instance.stubs(:id).returns(session_id)
+      session[:onboarding_session_id] = session_id
+    end
+
+    context 'when the reset_import param is passed' do
+      it "should clear the onboarding_session_id" do
+        expect{ subject }.to change{ session[:onboarding_session_id] }.from(session_id).to(nil)
+      end
+    end
+
+    context 'when the reset_import param is false' do
+      let(:reset_import) { false }
+
+      it "should not clear the onboarding_session_id" do
+        expect{ subject }.to_not change{ session[:onboarding_session_id] }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This clears onboarding_session_id when an import needs to be discarded to begin a new one.