### PR TITLE
handle ROO header row not found error

### DIFF
--- a/app/views/nfg_csv_importer/onboarding/_sub_layout.html.haml
+++ b/app/views/nfg_csv_importer/onboarding/_sub_layout.html.haml
@@ -20,6 +20,9 @@
     .container.py-4
       .row
         .col.col-lg-8.mx-auto
+          - if flash[:error].present?
+            = ui.nfg :alert, :danger, body: flash[:error]
+
           = ui.nfg :alert, :danger, body: f.object.errors.full_messages.join('<br/>').html_safe, icon: 'exclamation-circle', render_if: f.object.errors.any?
 
           = ui.nfg :tile do

--- a/app/views/nfg_csv_importer/onboarding/import_data/upload_preprocessing.html.haml
+++ b/app/views/nfg_csv_importer/onboarding/import_data/upload_preprocessing.html.haml
@@ -17,7 +17,8 @@
       - unless f.object.pre_processing_files.empty? || f.object.errors[:pre_processing_files].any?
         #stored_files
           - f.object.pre_processing_files.each do |file|
-            = f.hidden_field :pre_processing_files, multiple: true, value: file.signed_id, data: { name: file.try(:blob).try(:filename), size: file.try(:blob).try(:byte_size)}
+            - if file.respond_to? (:signed_id)
+              = f.hidden_field :pre_processing_files, multiple: true, value: file.signed_id, data: { name: file.try(:blob).try(:filename), size: file.try(:blob).try(:byte_size)}
 
   = ui.nfg :alert, :tip, class: 'mt-4 mb-0' do
     = ui.nfg :typeface, body: 'Have any questions about your import? Read this article.', class: 'mb-0'

--- a/config/locales/import_data.yml
+++ b/config/locales/import_data.yml
@@ -6,6 +6,7 @@ en:
           back: 'Prev'
           submit: 'Next'
       import_data:
+        invalid_headers: 'Error validating the headers for the import'
         file_extension: "The %{str_1} must be of xls, xlsx, or csv %{str_2}."
         title_bar:
           caption: "Import Your Data"

--- a/spec/features/importing_paypal_data_with_nfg_onboarder_spec.rb
+++ b/spec/features/importing_paypal_data_with_nfg_onboarder_spec.rb
@@ -31,6 +31,20 @@ describe "Using the nfg_onboarder engine to import paypal transactions", js: tru
       expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.upload_preprocessing.#{file_origination_type}"
     end
 
+    and_by 'attaching an invalid paypal file to the dropzone file field' do
+      drop_in_dropzone(File.expand_path("spec/fixtures/files/invalid_import.csv"))
+      page.find("div.progress-bar[style='width: 100%;']", wait: 10)
+      click_button "Next"
+    end
+
+    and_it 'prevents the user from continuing to the next step' do
+      expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.upload_preprocessing"
+    end
+
+    and_it 'shows the error message' do
+      expect(page).to have_content Roo::HeaderRowNotFoundError.new.message
+    end
+
     and_by 'attaching the a paypal file to the dropzone file field' do
       drop_in_dropzone(File.expand_path("spec/fixtures/paypal_sample_file.xlsx"))
       sleep 5
@@ -41,6 +55,10 @@ describe "Using the nfg_onboarder engine to import paypal transactions", js: tru
 
     and_it 'takes the user to the preview_confirmation page' do
       expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.preview_confirmation"
+    end
+
+    and_it 'should not have invalid header message anymore' do
+      expect(page).to_not have_content Roo::HeaderRowNotFoundError.new.message
     end
 
     and_by 'confirming the preview confirmation page it should kick off the import' do

--- a/spec/fixtures/files/invalid_import.csv
+++ b/spec/fixtures/files/invalid_import.csv
@@ -1,0 +1,2 @@
+invalid1,invalid2,invalid3
+a,b,c

--- a/spec/views/onboarding/sub_layout.html.haml_spec.rb
+++ b/spec/views/onboarding/sub_layout.html.haml_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'onboarding/sub_layout.html.haml' do
+  before do
+    # no need render the full sub layout (and all of its dependencies)
+    # since that should be tested elsewhere. We just need it to
+    # yield the block that is passed into it
+    stub_template "nfg_csv_importer/layouts/onboarding/import_data/_title_bar" => "<p></p>"
+    stub_template "nfg_csv_importer/layouts/onboarding/import_data/_navigation_bar" => "<p></p>"
+    view.stubs(:details).returns(details)
+    view.stubs(:flash).returns(flash_messages)
+    view.stubs(:locale_namespace).returns([:some_space])
+    view.stubs(:step).returns([:some_step])
+    view.stubs(:form).returns(form)
+    view.stubs(:wizard_path).returns('some/path')
+    view.stubs(:header_message).returns(mock('header_message', html_safe: 'message'))
+    form.stubs(:errors).returns(errors)
+    form.stubs(:model_name).returns(model_name)
+    form.stubs(:to_key).returns([])
+    model_name.stubs(:param_key).returns(form)
+    errors.stubs(:any?).returns(false)
+  end
+
+  let(:details) { %w[val, another_val] }
+  let(:flash_messages) { {error: 'some-error'} }
+  let(:form) { mock('form')}
+  let(:model_name) { mock('model_name') }
+  let(:errors) { mock('errors', full_messages: []) }
+  subject { render template: 'nfg_csv_importer/onboarding/_sub_layout.html.haml' }
+
+  context 'when there are flash messages' do
+    it 'should show flash messages' do
+      subject
+      rendered.should have_content(flash_messages[:error])
+    end
+  end
+end


### PR DESCRIPTION
- The right place to validate headers would be the pre processing form.  But it would be too heavy to download the file, check for headers and invalidate them.  it makes sense to validate it as part of downloading during our normal flow
- There is a corresponding yield handler in nfg_onboarder.  I don't have permissions to push to nfg_onboarder (please grant me the permissions).  

To make sense of it, all nfg_onboarder block does is:
current step makes sure the page doesn't go to preview confirmation on any refresh
```
        onboarding_session.update(current_step: step)
        @override_next_step = step
```

- Also there are corrensponding specs in donor_management, i'll create a PR for donor management, but it shouldn't be checked in until these are.