### PR TITLE
- get onboarder session from the import

### DIFF
--- a/app/controllers/nfg_csv_importer/onboarding/import_data_controller.rb
+++ b/app/controllers/nfg_csv_importer/onboarding/import_data_controller.rb
@@ -191,6 +191,8 @@ module NfgCsvImporter
       end
 
       def get_onboarding_session
+        # we have to find the onboarding session first from the user session, if we can't find it then we need to look at the params
+        # if still can't find it then we create a new onboarding session
         onboarding_sess = nil
         onboarding_sess = ::Onboarding::Session.find_by(id: session[:onboarding_session_id]) if session[:onboarding_session_id]
         onboarding_sess ||= get_import&.onboarding_session if params[:import_id]

--- a/app/controllers/nfg_csv_importer/onboarding/import_data_controller.rb
+++ b/app/controllers/nfg_csv_importer/onboarding/import_data_controller.rb
@@ -178,7 +178,7 @@ module NfgCsvImporter
       end
 
       def onboarder_name
-        "import_data"
+        "import_data_onboarder"
       end
 
       def get_file_origination_type_name
@@ -224,7 +224,7 @@ module NfgCsvImporter
           owner: nil,
           current_step: "file_origination_type_selection",  #typically the first step
           related_objects: {} ,# a hash containing the whatever object will be saved first, i.e. { project: get_project },
-          name: onboarder_name # this is a temporary name as form.model is nil and name presence is required for validations, this gets overridden with form model class in the onboarder gem.
+          name: onboarder_name
         }
       end
 

--- a/app/controllers/nfg_csv_importer/onboarding/import_data_controller.rb
+++ b/app/controllers/nfg_csv_importer/onboarding/import_data_controller.rb
@@ -33,7 +33,6 @@ module NfgCsvImporter
       # Each step has a presenter setup that, at minimum,
       # inherits the OnboarderPresenter.
       expose(:onboarder_presenter) { NfgCsvImporter::Onboarder::OnboarderPresenter.build(onboarding_session, view_context) }
-      # expose(:onboarder_presenter) { NfgCsvImporter::Onboarder::OnboarderPresenter.build(onboarding_session, view_context) }
 
       private
 
@@ -192,16 +191,9 @@ module NfgCsvImporter
       end
 
       def get_onboarding_session
-        # Use the following as an example of how an onboarding session would be either retrieved or instantiated
-        # We call new rather than create because we don't want the onboarding session
-        # to be saved if the user does not continue past the first step.
-        # onboarding_admin.onboarding_session_for(onboarder_name) || Onboarding::Session.new(onboarding_session_parameters)
-
-        # the following is a hack for the test app. So we can progress through the pages. It will need to be revised
-        # when used in DM. Not sure of the best way to do that.
         onboarding_sess = nil
         onboarding_sess = ::Onboarding::Session.find_by(id: session[:onboarding_session_id]) if session[:onboarding_session_id]
-        onboarding_sess ||= get_import&.get_session(name: onboarder_name) if params[:import_id]
+        onboarding_sess ||= get_import&.onboarding_session if params[:import_id]
         onboarding_sess ||= new_onboarding_session
         onboarding_sess.tap { |os| session[:onboarding_session_id] = os.id }
       end
@@ -232,7 +224,7 @@ module NfgCsvImporter
           owner: nil,
           current_step: "file_origination_type_selection",  #typically the first step
           related_objects: {} ,# a hash containing the whatever object will be saved first, i.e. { project: get_project },
-          name: onboarder_name
+          name: onboarder_name # this is a temporary name as form.model is nil and name presence is required for validations, this gets overridden with form model class in the onboarder gem.
         }
       end
 

--- a/app/models/nfg_csv_importer/import.rb
+++ b/app/models/nfg_csv_importer/import.rb
@@ -159,10 +159,6 @@ module NfgCsvImporter
       str
     end
 
-    def get_session(name: nil)
-      name.present? ? onboarding_session(name: name) : onboarding_session
-    end
-
     private
 
     def field_allowed_to_be_duplicated?(mapped_field)

--- a/app/models/nfg_csv_importer/import.rb
+++ b/app/models/nfg_csv_importer/import.rb
@@ -159,6 +159,10 @@ module NfgCsvImporter
       str
     end
 
+    def get_session(name: nil)
+      name.present? ? onboarding_session(name: name) : onboarding_session
+    end
+
     private
 
     def field_allowed_to_be_duplicated?(mapped_field)

--- a/app/models/nfg_csv_importer/import.rb
+++ b/app/models/nfg_csv_importer/import.rb
@@ -159,6 +159,11 @@ module NfgCsvImporter
       str
     end
 
+    def default_onboarder
+      # this is overriding onboardable_owner
+      "import_data_onboarder"
+    end
+
     private
 
     def field_allowed_to_be_duplicated?(mapped_field)

--- a/app/views/nfg_csv_importer/imports/_import.html.haml
+++ b/app/views/nfg_csv_importer/imports/_import.html.haml
@@ -29,8 +29,8 @@
 
       %div.text-xs-right{ class: imports_listing_row_column_structure_class }
         .btn-group
-          - if import.uploaded?
-            = link_to nfg_csv_importer.onboarding_import_data_path(import_id: import.id), class: 'btn btn-secondary' do
+          - if import.uploaded? # we need to disable turbolinks for this link as it sends multiple requests
+            = link_to nfg_csv_importer.onboarding_import_data_path(import_id: import.id), class: 'btn btn-secondary', data: { turbolinks: false } do
               = fa_icon 'pencil'
               %span.m-l-quarter.hidden-sm-down= t("links.edit_import", scope: language_scope)
 

--- a/spec/controllers/nfg_csv_importer/onboarding/import_data_controller_spec.rb
+++ b/spec/controllers/nfg_csv_importer/onboarding/import_data_controller_spec.rb
@@ -10,6 +10,7 @@ describe NfgCsvImporter::Onboarding::ImportDataController do
   before do
     NfgCsvImporter::FileOriginationTypes::Manager.any_instance.stubs(:type_for).returns(file_origination_type)
     file_origination_type.expects(:skip_steps).at_least_once
+    file_origination_type.stubs(:requires_post_processing_file).returns(true)
   end
 
   render_views

--- a/spec/features/importing_paypal_data_with_nfg_onboarder_spec.rb
+++ b/spec/features/importing_paypal_data_with_nfg_onboarder_spec.rb
@@ -5,8 +5,7 @@ describe "Using the nfg_onboarder engine to import paypal transactions", js: tru
   let(:admin) {  create(:user) }
   let(:file_origination_type) { 'paypal' }
 
-  it 'walks the user through selecting the paypal file and eventually imports the donors/donations in the file' do
-
+  def visiting_till_the_preview_confirmation_page
     by 'visiting the index page' do
       visit nfg_csv_importer.imports_path
     end
@@ -56,6 +55,10 @@ describe "Using the nfg_onboarder engine to import paypal transactions", js: tru
     and_it 'takes the user to the preview_confirmation page' do
       expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.preview_confirmation"
     end
+  end
+
+  it 'walks the user through selecting the paypal file and eventually imports the donors/donations in the file' do
+    visiting_till_the_preview_confirmation_page
 
     and_it 'should not have invalid header message anymore' do
       expect(page).to_not have_content Roo::HeaderRowNotFoundError.new.message
@@ -93,6 +96,21 @@ describe "Using the nfg_onboarder engine to import paypal transactions", js: tru
       # we show how many records were added
       # In production, we will likely have different messages depending on the status of the import
       expect(page).to have_content "You've finished this import! There were a total of 4 records"
+    end
+  end
+
+  it 'leaves the onboarder flow and then clicks on edit on index page to land back at the last step' do
+    visiting_till_the_preview_confirmation_page
+    and_by 'visiting the imports index page' do
+      visit nfg_csv_importer.imports_path
+    end
+
+    and_by 'clicking the edit button' do
+      click_link "Edit"
+    end
+
+    and_it 'takes the user back to the preview confirmation page' do
+      expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.preview_confirmation"
     end
   end
 end

--- a/spec/features/importing_paypal_data_with_nfg_onboarder_spec.rb
+++ b/spec/features/importing_paypal_data_with_nfg_onboarder_spec.rb
@@ -5,58 +5,6 @@ describe "Using the nfg_onboarder engine to import paypal transactions", js: tru
   let(:admin) {  create(:user) }
   let(:file_origination_type) { 'paypal' }
 
-  def visiting_till_the_preview_confirmation_page
-    by 'visiting the index page' do
-      visit nfg_csv_importer.imports_path
-    end
-
-    and_by 'clicking the get started link' do
-      page.find("[data-describe='import-data-onboarder-cta']").click
-    end
-
-    and_it 'takes the user to the onboarder at the first step - file origination type selection' do
-      expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.file_origination_type_selection"
-    end
-
-    and_by 'selecting a file origination type' do
-      page.find("label[for='nfg_csv_importer_onboarding_import_data_file_origination_type_selection_file_origination_type_#{file_origination_type}']").click
-    end
-
-    and_by 'submitting the form / clicking the `next` button' do
-      click_button 'Next'
-    end
-
-    and_it 'takes the user to the upload_preprocessing step' do
-      expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.upload_preprocessing.#{file_origination_type}"
-    end
-
-    and_by 'attaching an invalid paypal file to the dropzone file field' do
-      drop_in_dropzone(File.expand_path("spec/fixtures/files/invalid_import.csv"))
-      page.find("div.progress-bar[style='width: 100%;']", wait: 10)
-      click_button "Next"
-    end
-
-    and_it 'prevents the user from continuing to the next step' do
-      expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.upload_preprocessing"
-    end
-
-    and_it 'shows the error message' do
-      expect(page).to have_content Roo::HeaderRowNotFoundError.new.message
-    end
-
-    and_by 'attaching the a paypal file to the dropzone file field' do
-      drop_in_dropzone(File.expand_path("spec/fixtures/paypal_sample_file.xlsx"))
-      sleep 5
-      page.find("div.progress-bar[style='width: 100%;']", wait: 10)
-      expect { click_button 'Next' }.to change(NfgCsvImporter::Import, :count).by(1)
-      @import = NfgCsvImporter::Import.last
-    end
-
-    and_it 'takes the user to the preview_confirmation page' do
-      expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.preview_confirmation"
-    end
-  end
-
   it 'walks the user through selecting the paypal file and eventually imports the donors/donations in the file' do
     visiting_till_the_preview_confirmation_page
 

--- a/spec/models/nfg_csv_importer/import_spec.rb
+++ b/spec/models/nfg_csv_importer/import_spec.rb
@@ -555,22 +555,4 @@ describe NfgCsvImporter::Import do
     end
 
   end
-
-  describe '#get_session' do
-    let(:name) { import.class.to_s.underscore + "_onboarder" }
-
-    let!(:onboarding_session) { create(:onboarding_session, name: name, owner: import) }
-
-    context 'when name is not passed' do
-      subject { import.get_session }
-
-      it 'should return the right session' do
-        expect(subject.id).to eq(onboarding_session.id)
-      end
-    end
-
-    context 'when name is passed in' do
-      #TODO: WRITE SPECS WHEN NFG_ONBOARDER change is merged in
-    end
-  end
 end

--- a/spec/models/nfg_csv_importer/import_spec.rb
+++ b/spec/models/nfg_csv_importer/import_spec.rb
@@ -555,4 +555,10 @@ describe NfgCsvImporter::Import do
     end
 
   end
+
+  describe '#default_onboarder' do
+    subject { import.default_onboarder }
+
+    it { is_expected.to eq "import_data_onboarder"}
+  end
 end

--- a/spec/models/nfg_csv_importer/import_spec.rb
+++ b/spec/models/nfg_csv_importer/import_spec.rb
@@ -555,4 +555,22 @@ describe NfgCsvImporter::Import do
     end
 
   end
+
+  describe '#get_session' do
+    let(:name) { import.class.to_s.underscore + "_onboarder" }
+
+    let!(:onboarding_session) { create(:onboarding_session, name: name, owner: import) }
+
+    context 'when name is not passed' do
+      subject { import.get_session }
+
+      it 'should return the right session' do
+        expect(subject.id).to eq(onboarding_session.id)
+      end
+    end
+
+    context 'when name is passed in' do
+      #TODO: WRITE SPECS WHEN NFG_ONBOARDER change is merged in
+    end
+  end
 end

--- a/spec/support/onboarding/spec_helpers.rb
+++ b/spec/support/onboarding/spec_helpers.rb
@@ -1,0 +1,51 @@
+def visiting_till_the_preview_confirmation_page
+  by 'visiting the index page' do
+    visit nfg_csv_importer.imports_path
+  end
+
+  and_by 'clicking the get started link' do
+    page.find("[data-describe='import-data-onboarder-cta']").click
+  end
+
+  and_it 'takes the user to the onboarder at the first step - file origination type selection' do
+    expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.file_origination_type_selection"
+  end
+
+  and_by 'selecting a file origination type' do
+    page.find("label[for='nfg_csv_importer_onboarding_import_data_file_origination_type_selection_file_origination_type_#{file_origination_type}']").click
+  end
+
+  and_by 'submitting the form / clicking the `next` button' do
+    click_button 'Next'
+  end
+
+  and_it 'takes the user to the upload_preprocessing step' do
+    expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.upload_preprocessing.#{file_origination_type}"
+  end
+
+  and_by 'attaching an invalid paypal file to the dropzone file field' do
+    drop_in_dropzone(File.expand_path("spec/fixtures/files/invalid_import.csv"))
+    page.find("div.progress-bar[style='width: 100%;']", wait: 10)
+    click_button "Next"
+  end
+
+  and_it 'prevents the user from continuing to the next step' do
+    expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.upload_preprocessing"
+  end
+
+  and_it 'shows the error message' do
+    expect(page).to have_content Roo::HeaderRowNotFoundError.new.message
+  end
+
+  and_by 'attaching the a paypal file to the dropzone file field' do
+    drop_in_dropzone(File.expand_path("spec/fixtures/paypal_sample_file.xlsx"))
+    sleep 5
+    page.find("div.progress-bar[style='width: 100%;']", wait: 10)
+    expect { click_button 'Next' }.to change(NfgCsvImporter::Import, :count).by(1)
+    @import = NfgCsvImporter::Import.last
+  end
+
+  and_it 'takes the user to the preview_confirmation page' do
+    expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.preview_confirmation"
+  end
+end


### PR DESCRIPTION
- This needs to wait for a change in nfg_onboarder. I don't have access to push to nfg onboarder. 
- disable turbolinks for edit link as it makes multiple calls and messes up referred_by_us?
The edit link on imports index page messes up with turbolinks.  Turbolinks for some reason makes multiple requests to onboarder.  The first time the request goes through to onboarder it works fine, the second time however, it sets up referred_by_us? and importer goes back to the file origination step instead of the last step they were on.  the browser kept hiding the request after the refresh, and backend kept showing multiple request it was a pain to figure out what the heck was initiating the request.  it only took about 5 hours until 4 am on friday night.
- also reset onboarding_import_data_import_id
- find onboarder by import_id