### PR TITLE
Adds simple_formatting to supply line breaks to notes.

### DIFF
--- a/app/views/nfg_csv_importer/imports/show.html.haml
+++ b/app/views/nfg_csv_importer/imports/show.html.haml
@@ -115,7 +115,7 @@
           - if @import.file_origination_type.collect_note_with_pre_processing_files
             #note.m-b-base
               %h5 Your notes
-              %p= import_presenter.import_note
+              %p= simple_format(import_presenter.import_note)
 
 
           - if import_presenter.show_files?


### PR DESCRIPTION
Customer notes were not being formatted and line breaks were being lost on the imports/show page. https://jira.networkforgood.org/browse/DM-5850

This addresses it by adding simple_format to the note.