### PR TITLE
Hotfix/dm 5863 display account name at topleft of the importing procedure

### DIFF
--- a/app/presenters/nfg_csv_importer/onboarder/title_bar_presenter.rb
+++ b/app/presenters/nfg_csv_importer/onboarder/title_bar_presenter.rb
@@ -1,0 +1,10 @@
+module NfgCsvImporter
+  module Onboarder
+    # Ex: NfgCsvImporter::Onboarder::TitleBarPresenter.new(onboarding_session)
+    class TitleBarPresenter < NfgCsvImporter::Onboarder::OnboarderPresenter
+      def title_bar_caption
+        I18n.t('nfg_csv_importer.onboarding.import_data.title_bar.caption')
+      end
+    end
+  end
+end

--- a/app/views/nfg_csv_importer/layouts/onboarding/import_data/_title_bar.html.haml
+++ b/app/views/nfg_csv_importer/layouts/onboarding/import_data/_title_bar.html.haml
@@ -1,10 +1,10 @@
 - show_exit_button = true if local_assigns[:show_exit_button].nil?
-- caption = t('nfg_csv_importer.onboarding.import_data.title_bar.caption') if local_assigns[:caption].nil?
+- title_bar_presenter = NfgCsvImporter::Onboarder::TitleBarPresenter.new(onboarding_session, self)
 
 .p-2.bg-dark
   .row.align-items-center.justify-content-between
     .col.pl-3
-      = ui.nfg :typeface, :muted, caption: caption, class: 'mb-0', describe: 'onboarder-caption'
+      = ui.nfg :typeface, :muted, caption: title_bar_presenter.title_bar_caption, class: 'mb-0', describe: 'onboarder-caption'
       = ui.nfg :typeface, title: file_origination_type&.name, class: 'text-white', render_if: file_origination_type.present?
 
     - if show_exit_button

--- a/app/views/nfg_csv_importer/layouts/onboarding/import_data/_title_bar.html.haml
+++ b/app/views/nfg_csv_importer/layouts/onboarding/import_data/_title_bar.html.haml
@@ -1,9 +1,10 @@
 - show_exit_button = true if local_assigns[:show_exit_button].nil?
+- caption = t('nfg_csv_importer.onboarding.import_data.title_bar.caption') if local_assigns[:caption].nil?
 
 .p-2.bg-dark
   .row.align-items-center.justify-content-between
     .col.pl-3
-      = ui.nfg :typeface, :muted, caption: t('nfg_csv_importer.onboarding.import_data.title_bar.caption'), class: 'mb-0'
+      = ui.nfg :typeface, :muted, caption: caption, class: 'mb-0', describe: 'onboarder-caption'
       = ui.nfg :typeface, title: file_origination_type&.name, class: 'text-white', render_if: file_origination_type.present?
 
     - if show_exit_button

--- a/app/views/nfg_csv_importer/onboarding/_sub_layout.html.haml
+++ b/app/views/nfg_csv_importer/onboarding/_sub_layout.html.haml
@@ -12,7 +12,7 @@
 - hide_navigation_bar = false if local_assigns[:hide_navigation_bar].nil?
 
 = simple_form_for form, url: wizard_path, html: { id: 'onboarding_main_form', multipart: true, autocomplete: 'off', class: ('was-validated' if form.errors.any?), novalidate: form.errors.any? }, method: :put do |f|
-  = render partial: "nfg_csv_importer/layouts/onboarding/import_data/title_bar", locals: { show_exit_button: show_exit_button }
+  = render partial: "layouts/onboarding/import_data/title_bar", locals: { show_exit_button: show_exit_button }
 
   - unless hide_navigation_bar
     = render partial: 'nfg_csv_importer/layouts/onboarding/import_data/navigation_bar', locals: { back_button_text: back_button_text, submit_button_text: submit_button_text, next_step_confirmation: next_step_confirmation }

--- a/app/views/nfg_csv_importer/onboarding/_sub_layout.html.haml
+++ b/app/views/nfg_csv_importer/onboarding/_sub_layout.html.haml
@@ -12,7 +12,7 @@
 - hide_navigation_bar = false if local_assigns[:hide_navigation_bar].nil?
 
 = simple_form_for form, url: wizard_path, html: { id: 'onboarding_main_form', multipart: true, autocomplete: 'off', class: ('was-validated' if form.errors.any?), novalidate: form.errors.any? }, method: :put do |f|
-  = render partial: "layouts/onboarding/import_data/title_bar", locals: { show_exit_button: show_exit_button }
+  = render partial: "nfg_csv_importer/layouts/onboarding/import_data/title_bar", locals: { show_exit_button: show_exit_button }
 
   - unless hide_navigation_bar
     = render partial: 'nfg_csv_importer/layouts/onboarding/import_data/navigation_bar', locals: { back_button_text: back_button_text, submit_button_text: submit_button_text, next_step_confirmation: next_step_confirmation }


### PR DESCRIPTION
https://jira.networkforgood.org/browse/DM-5863

The sysadmin/syssupport team has requested the ability to see the entity name on the title bar / masthead of the import onboarder. This creates an environment for that to happen.

See associated DMS PR: https://github.com/network-for-good/donor_management/pull/1598

I initially explored the partial approach but that created headaches. Ultimately, I went with a presenter for the titlebar which can be overwritten by the host app with ease. That pattern is in play and active in the associated DMS branch.

This branch must be merged into `rails_5` before the DMS PR can be merged in.