### PR TITLE
Adds CSS ID to the finish step for fullstory tracking.

### DIFF
--- a/app/views/nfg_csv_importer/onboarding/import_data/finish.html.haml
+++ b/app/views/nfg_csv_importer/onboarding/import_data/finish.html.haml
@@ -1,6 +1,6 @@
 = render layout: 'nfg_csv_importer/onboarding/sub_layout', locals: { show_exit_button: false } do |f|
 
-  .text-center
+  %div{ class: 'text-center', id: file_origination_type.type_sym }
     -# Due to some malfeasance within rails, if the last render fails
     -# the error message will indicate only that it tried to render the first partial
     - begin

--- a/spec/views/onboarding/import_data/finish.html.haml_spec.rb
+++ b/spec/views/onboarding/import_data/finish.html.haml_spec.rb
@@ -11,14 +11,19 @@ RSpec.describe 'onboarding/import_data/finish.html.haml' do
     view.stubs(:import).returns(stub(id: 1, status: status, imported_records: stub(count: 4), number_of_records: 4, number_of_records_with_errors: 0))
     view.stubs(:onboarder_presenter).returns(onboarder_presenter)
     view.stubs(:locale_namespace).returns([:nfg_csv_importer, :onboarding, :import_data])
+    view.stubs(:file_origination_type).returns(file_origination_type)
     # view.stubs(:step).returns(:finish)
   end
-
+  let(:file_origination_type) { OpenStruct.new(type_sym: 'paypal') }
   let(:file_origination_type_name) { "paypal" }
   let(:status) { "complete" }
   let(:onboarder_presenter) { OpenStruct.new(queued_alert_msg: 'Your import is next in line.') }
 
   subject { render template: 'nfg_csv_importer/onboarding/import_data/finish' }
+
+  it 'includes the file origination type symbol as an id used by the Full Story app' do
+    expect(subject).to have_css "#paypal"
+  end
 
   context 'when the file_origination_type_name and import status have a matching partial' do
 


### PR DESCRIPTION
https://jira.networkforgood.org/browse/DM-5984

Elicia needed a custom CSS ID (body tag with css classes wasn't working for some reason) to track the file origination type that was imported for full story. This adds a file origination type named CSS ID on the finish step.