### PR TITLE
Feature/dm 6208 allow index page to be hidden using a rails cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
       config.from_address = Rails.configuration.default_from_address
       config.reply_to_address = Rails.configuration.default_from_address
       config.additional_file_origination_types = [:constant_contact, :sales_force, :kindful]
+      config.disable_import_initiation_message = ->(user) { user.can_import? ? nil : "You do not have permission to initiate an import" }
     end
     ````
 
@@ -28,6 +29,10 @@
     If the additional_file_origination_types is assigned no value, or is assigned an empty array, the user will not be given any file types to
     select and will proceed to select the type of import they want to
     complete.
+
+    #disable_import_initiation_message must be a proc that accepts the current user. It must return nil, or an html string that will be displayed the header area on the index page where new imports are kicked off from. It is likely that it would use some authorization scheme like CanCanCan or Pundit in this proc. Though it also could include a check for a Rails.cache key so it could be set at any time. It could also just always return nil, if users of the parent app can always import. If nothing is passed, or if something is passed that is not callable, imports will not be disabled.
+
+    This also disables completing an import that was not finished
 
 3. Add has_many relationships to any relevant models. Make sure you specify the foreign key.
 

--- a/app/controllers/nfg_csv_importer/imports_controller.rb
+++ b/app/controllers/nfg_csv_importer/imports_controller.rb
@@ -133,6 +133,15 @@ class NfgCsvImporter::ImportsController < NfgCsvImporter::ApplicationController
     render json: {}, status: :not_found
   end
 
+  def disable_import_initiation_message
+    return if NfgCsvImporter::Configuration.disable_import_initiation_message.nil?
+
+    return unless NfgCsvImporter::Configuration.disable_import_initiation_message.respond_to?(:call)
+
+    NfgCsvImporter::Configuration.disable_import_initiation_message.call(current_user)
+  end
+  helper_method :disable_import_initiation_message
+
   protected
   # the standard event tracking (defined in application controller) attempts to include
   # the imported file, which crashes the write to the db. So here we only track the type of import
@@ -160,5 +169,4 @@ class NfgCsvImporter::ImportsController < NfgCsvImporter::ApplicationController
   def iframe_param_present?
     params[:iframe].present?
   end
-
 end

--- a/app/controllers/nfg_csv_importer/imports_controller.rb
+++ b/app/controllers/nfg_csv_importer/imports_controller.rb
@@ -134,11 +134,11 @@ class NfgCsvImporter::ImportsController < NfgCsvImporter::ApplicationController
   end
 
   def disable_import_initiation_message
-    return if NfgCsvImporter::Configuration.disable_import_initiation_message.nil?
-
-    return unless NfgCsvImporter::Configuration.disable_import_initiation_message.respond_to?(:call)
-
-    NfgCsvImporter::Configuration.disable_import_initiation_message.call(current_user)
+    NfgCsvImporter.configuration.disable_import_initiation_message.call(current_user)
+  rescue
+    # we may get here if the disable_import_initiation_message is not configured
+    # or if it is not callable, or raises an error when called.
+    nil
   end
   helper_method :disable_import_initiation_message
 

--- a/app/views/nfg_csv_importer/imports/_import.html.haml
+++ b/app/views/nfg_csv_importer/imports/_import.html.haml
@@ -11,7 +11,7 @@
         %p.m-t-quarter.small= import.updated_at.to_s(:abrev_month_yyyy)
 
       %div{ class: 'col-md-3 m-b-half-down-sm' }
-        %h5{ data: { describe: 'file-origination-type' } }= import_presenter.file_origination_type_name
+        %h5{ data: { describe: 'file-origination-type' } }=   import_presenter.file_origination_type_name
         %p.m-t-quarter.small
           %strong= import_status_link(import)
 
@@ -23,8 +23,9 @@
 
       %div.text-xs-right{ class: 'col-md-2 m-b-half-down-sm' }
         .btn-group
-          - if import.pending_or_uploaded_or_calculating_statistics? # we need to disable turbolinks for this link as it sends multiple requests
-            = link_to edit_import_path(import), class: 'btn btn-secondary', data: { turbolinks: false } do
+          - if import.pending_or_uploaded_or_calculating_statistics? && disable_import_initiation_message.blank?
+            - # we need to disable turbolinks for this link as it sends multiple requests
+            = link_to nfg_csv_importer.edit_import_path(import), class: 'btn btn-secondary', data: { turbolinks: false, describe: 'edit-import' } do
               = fa_icon 'pencil'
               %span.m-l-quarter.hidden-sm-down= t("links.edit_import", scope: language_scope)
 
@@ -41,5 +42,5 @@
                   = fa_icon 'download', class: 'm-r-quarter', text: t("links.download", scope: language_scope)
 
               - if import.can_be_deleted?(current_user)
-                = link_to import_path(import), method: :delete, class: 'dropdown-item text-danger', data: { confirm: import_delete_confirmation(import) } do
+                = link_to nfg_csv_importer.import_path(import), method: :delete, class: 'dropdown-item text-danger', data: { confirm: import_delete_confirmation(import) } do
                   = fa_icon 'trash-o', class: 'm-r-quarter', text: t("links.delete_import", scope: language_scope)

--- a/app/views/nfg_csv_importer/imports/index.html.haml
+++ b/app/views/nfg_csv_importer/imports/index.html.haml
@@ -6,7 +6,7 @@
       .container-fluid
         .row
           .col-xs-12.p-x-2.text-white
-            - if disable_import_initiation_message
+            - if disable_import_initiation_message.present?
               -# At times we need to not allow new imports to begin,
               -# such as on Giving Tuesday. The below variable
               -#  comes from the imports control controller method

--- a/app/views/nfg_csv_importer/imports/index.html.haml
+++ b/app/views/nfg_csv_importer/imports/index.html.haml
@@ -6,10 +6,16 @@
       .container-fluid
         .row
           .col-xs-12.p-x-2.text-white
-            %h1.text-xs-center= t('.jumbotron.headline').html_safe
-            %p.text-xs-center.m-b-base= t('.jumbotron.sub_headline')
-            - button_text = session[:onboarding_session_id].nil? ? 'begin' : 'continue'
-            = ui.nfg :button, :secondary, :lg, body: t(".buttons.#{button_text}", name: 'get_started'), href: nfg_csv_importer.onboarding_import_data_path, describe: 'import-data-onboarder-cta', data: { turbolinks: false }
+            - if disable_import_initiation_message
+              -# At times we need to not allow new imports to begin,
+              -# such as on Giving Tuesday. The below variable
+              -#  comes from the imports control controller method
+              = disable_import_initiation_message.html_safe
+            - else
+              %h1.text-xs-center= t('.jumbotron.headline').html_safe
+              %p.text-xs-center.m-b-base= t('.jumbotron.sub_headline')
+              - button_text = session[:onboarding_session_id].nil? ? 'begin' : 'continue'
+              = ui.nfg :button, :secondary, :lg, body: t(".buttons.#{button_text}", name: 'get_started'), href: nfg_csv_importer.onboarding_import_data_path, describe: 'import-data-onboarder-cta', data: { turbolinks: false }
   .container-fluid
     = render(partial: 'shared/flash_messages') rescue nil
     .row

--- a/lib/nfg_csv_importer/configuration.rb
+++ b/lib/nfg_csv_importer/configuration.rb
@@ -2,7 +2,7 @@ module NfgCsvImporter
   class Configuration
     attr_accessor :imported_for_class, :imported_by_class, :base_controller_class,
                   :from_address, :reply_to_address, :imported_for_subdomain, :max_run_time, :additional_file_origination_types,
-                  :high_priority_queue_name
+                  :high_priority_queue_name, :disable_import_initiation_message
 
     def imported_for_field
       (imported_for_class.downcase + "_id")

--- a/spec/controllers/imports_controller_spec.rb
+++ b/spec/controllers/imports_controller_spec.rb
@@ -278,4 +278,42 @@ describe NfgCsvImporter::ImportsController do
       end
     end
   end
+
+  describe '#disable_import_initiation_message' do
+    before do
+      NfgCsvImporter::Configuration.stubs(:disable_import_initiation_message).returns(disable_import_initiation_message)
+    end
+
+    subject { controller.disable_import_initiation_message }
+
+    context "when nothing has been configured for the disable_import_initiation_message configuration" do
+      let(:disable_import_initiation_message) { nil }
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when disable_import_initiation_message has been configured, but not with a callable object" do
+      let(:disable_import_initiation_message) { 'true' }
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'when disable_import_initiation_message is callable' do
+      let(:disable_import_initiation_message) { ->(user) { "I am here" } }
+
+      it 'returns the value returned from the proc' do
+        expect(subject).to eq("I am here")
+      end
+    end
+
+    # context "when the rails cache holds no value for the disable import initiate message" do
+    #   it 'is nil' do
+    #     expect(subject).to be_nil
+    #   end
+    # end
+  end
 end

--- a/spec/controllers/imports_controller_spec.rb
+++ b/spec/controllers/imports_controller_spec.rb
@@ -322,7 +322,7 @@ describe NfgCsvImporter::ImportsController do
 
   describe '#disable_import_initiation_message' do
     before do
-      NfgCsvImporter::Configuration.stubs(:disable_import_initiation_message).returns(disable_import_initiation_message)
+      NfgCsvImporter.configuration.stubs(:disable_import_initiation_message).returns(disable_import_initiation_message)
     end
 
     subject { controller.disable_import_initiation_message }
@@ -350,11 +350,5 @@ describe NfgCsvImporter::ImportsController do
         expect(subject).to eq("I am here")
       end
     end
-
-    # context "when the rails cache holds no value for the disable import initiate message" do
-    #   it 'is nil' do
-    #     expect(subject).to be_nil
-    #   end
-    # end
   end
 end

--- a/spec/test_app/config/initializers/nfg_csv_importer.rb
+++ b/spec/test_app/config/initializers/nfg_csv_importer.rb
@@ -6,4 +6,5 @@ NfgCsvImporter.configure do |config|
   config.reply_to_address = Rails.configuration.default_from_address
   config.imported_for_subdomain = :subdomain
   config.additional_file_origination_types = [:paypal, :send_to_nfg]
+  config.disable_import_initiation_message = -> (user) { user.last_name == 'noob' ? "You can't see it" : nil }
 end

--- a/spec/views/imports/_import.html.haml_spec.rb
+++ b/spec/views/imports/_import.html.haml_spec.rb
@@ -9,10 +9,12 @@ RSpec.describe "nfg_csv_importer/imports/_imports.html.haml", type: :view do
   let(:current_user) { FactoryGirl.create(:user) }
   let(:imported_by) { current_user }
   let(:tested_can_be_viewed_by) { true }
+  let(:disable_import_initiation_message) { nil }
 
   before do
     view.stubs(:current_user).returns(current_user)
     import.stubs(:can_be_viewed_by).with(current_user).returns(tested_can_be_viewed_by)
+    view.stubs(:disable_import_initiation_message).returns(disable_import_initiation_message)
   end
 
   subject { render partial: 'nfg_csv_importer/imports/import', locals: { import_presenter: import_presenter, import: import, imports_listing_row_column_structure_class: imports_listing_row_column_structure_class } }
@@ -33,6 +35,23 @@ RSpec.describe "nfg_csv_importer/imports/_imports.html.haml", type: :view do
 
       and_it 'displays the number of imported records' do
         expect(subject).to have_selector "[data-describe='amount-of-records-without-errors']", text: import.records_processed
+      end
+    end
+
+    context "and the import is not complete" do
+      let(:import_traits) { [:pending, :is_paypal] }
+      context 'and disable_import_initiation_message is nil' do
+        it 'shows the link to continue the import' do
+          expect(subject).to have_selector("[data-describe='edit-import']")
+        end
+      end
+
+      context 'and disable_import_initiation_message is not nil' do
+        let(:disable_import_initiation_message) { "you can't see it" }
+
+        it 'does not show the link to continue the import' do
+          expect(subject).not_to have_selector("[data-describe='edit-import']")
+        end
       end
     end
 

--- a/spec/views/imports/index.html.haml_spec.rb
+++ b/spec/views/imports/index.html.haml_spec.rb
@@ -8,17 +8,38 @@ RSpec.describe "nfg_csv_importer/imports/index.html.haml", type: :view do
   let(:import_traits) { [:is_complete, :is_paypal] }
   let!(:imports) { assign(:imports, [import]) }
   let(:tested_can_be_viewed_by) { false }
+  let(:disable_import_initiation_message) { nil }
 
   before do
     view.extend NfgCsvImporter::ImportsHelper
+    # TODO: the below works only because the two including applications expose
+    # current_user. Instead, we should have an nfg_importer_user that
+    # gets its value from the imported_by configuration setting. We  should
+    # also consider changing that to configuration setting from being a class
+    # to being the helper method in the included application (ie. current_user, current_admin, etc)
     view.stubs(:current_user).returns(current_user)
     view.stubs(:import).returns(import)
+    view.stubs(:disable_import_initiation_message).returns(disable_import_initiation_message)
   end
 
   subject { render }
 
-  it 'renders the header with a CTA link' do
-    expect(subject).to have_css "[data-describe='import-data-onboarder-cta']"
+  context 'when disable_import_initiation_message returns nil' do
+    it 'renders the header with a CTA link' do
+      expect(subject).to have_css "[data-describe='import-data-onboarder-cta']"
+    end
+  end
+
+  context "when the disable_import_initiation_message returns a message" do
+    let(:disable_import_initiation_message) { 'No Imports Today' }
+
+    it 'does not render the header with a CTA link' do
+      expect(subject).not_to have_css "[data-describe='import-data-onboarder-cta']"
+    end
+
+    it 'displays the message from the disable_import_initiation_message' do
+      expect(subject).to have_content(disable_import_initiation_message)
+    end
   end
 
   describe 'the imports listing' do


### PR DESCRIPTION
This allows us to hide the button that starts a new import and also removes the ability to complete an import. This only affects non-sys users