### PR TITLE
fix undefined method downcase on nil file origination type name

### DIFF
--- a/app/controllers/nfg_csv_importer/onboarding/import_data_controller.rb
+++ b/app/controllers/nfg_csv_importer/onboarding/import_data_controller.rb
@@ -178,12 +178,16 @@ module NfgCsvImporter
         # we have to find the onboarding session first from the user session, if we can't find it then we need to look at the params
         # if still can't find it then we create a new onboarding session
         onboarding_sess = nil
-        onboarding_sess = ::Onboarding::Session.find_by(id: session[:onboarding_session_id]) if session[:onboarding_session_id]
-        import = onboarding_sess&.owner
+        import = nil
 
-        if onboarding_sess.blank? && params[:import_id]
+        if params[:import_id].present?
           import = get_import
           onboarding_sess = import&.onboarding_session
+        end
+
+        if onboarding_sess.blank? && session[:onboarding_session_id].present?
+          onboarding_sess = ::Onboarding::Session.find_by(id: session[:onboarding_session_id])
+          import = onboarding_sess&.owner
         end
 
         # We do not want to get onboarder session for imports to be deleted

--- a/app/controllers/nfg_csv_importer/onboarding/import_data_controller.rb
+++ b/app/controllers/nfg_csv_importer/onboarding/import_data_controller.rb
@@ -185,7 +185,7 @@ module NfgCsvImporter
           onboarding_sess = import&.onboarding_session
         end
 
-        if onboarding_sess.blank? && session[:onboarding_session_id].present?
+        if import.nil? && session[:onboarding_session_id].present?
           onboarding_sess = ::Onboarding::Session.find_by(id: session[:onboarding_session_id])
           import = onboarding_sess&.owner
         end

--- a/spec/features/importing_paypal_data_with_nfg_onboarder_spec.rb
+++ b/spec/features/importing_paypal_data_with_nfg_onboarder_spec.rb
@@ -122,4 +122,35 @@ describe "Using the nfg_onboarder engine to import paypal transactions", js: tru
       expect(page).to have_content I18n.t('nfg_csv_importer.imports.show.imported_by')
     end
   end
+
+  context 'when creating two simultaneous imports' do
+    it 'succesfully shifts to the right import when editing' do
+      visiting_till_the_preview_confirmation_page
+
+      and_by 'visiting the imports index page' do
+        click_link "Exit"
+      end
+
+      and_by 'opening a new tab and switching to it' do
+        open_new_window
+        switch_to_window windows.last
+      end
+
+      and_by 'starting a new import on the new tab' do
+        visiting_till_the_file_origination_type_selection_page
+      end
+
+      and_by 'switching to the first tab with index page again' do
+        switch_to_window windows.first
+      end
+
+      and_by 'clicking the edit button of the first import' do
+        click_link "Edit"
+      end
+
+      and_it 'takes the user to the preview_confirmation page' do
+        expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.preview_confirmation"
+      end
+    end
+  end
 end

--- a/spec/support/onboarding/spec_helpers.rb
+++ b/spec/support/onboarding/spec_helpers.rb
@@ -33,17 +33,7 @@ def visiting_till_the_preview_confirmation_page
 end
 
 def visiting_till_the_upload_preprocessing_page
-  by 'visiting the index page' do
-    visit nfg_csv_importer.imports_path
-  end
-
-  and_by 'clicking the get started link' do
-    page.find("[data-describe='import-data-onboarder-cta']").click
-  end
-
-  and_it 'takes the user to the onboarder at the first step - file origination type selection' do
-    expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.file_origination_type_selection"
-  end
+  visiting_till_the_file_origination_type_selection_page
 
   and_by 'selecting a file origination type' do
     page.find("label[for='nfg_csv_importer_onboarding_import_data_file_origination_type_selection_file_origination_type_#{file_origination_type}']").click
@@ -55,6 +45,20 @@ def visiting_till_the_upload_preprocessing_page
 
   and_it 'takes the user to the upload_preprocessing step' do
     expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.upload_preprocessing.#{file_origination_type}"
+  end
+end
+
+def visiting_till_the_file_origination_type_selection_page
+  by 'visiting the index page' do
+    visit nfg_csv_importer.imports_path
+  end
+
+  and_by 'clicking the get started link' do
+    page.find("[data-describe='import-data-onboarder-cta']").click
+  end
+
+  and_it 'takes the user to the onboarder at the first step - file origination type selection' do
+    expect(page).to have_css "body.nfg_csv_importer-onboarding-import_data.file_origination_type_selection"
   end
 end
 


### PR DESCRIPTION
The edit method for imports_controller has this condition:
```
    if @import.onboarding_session.present? && params[:iframe].blank?
      return redirect_to nfg_csv_importer.onboarding_import_data_path(import_id: @import.id)
    end
```
and imports_data_controller uses session's onboarder_session_id  before using the import_id to find the onboarding_session.  In a scenario where there is a different onboarder_session_id in the session rather than the onboarder_session_id of the import for which the edit button was clicked on the imports index page, this causes an issue where wrong onboarder session is loaded.

We should always give precedence to the import whose specific id was passed before looking at the session.

This fixes the issue along with the specs.