### PR TITLE
Use deliver_later instead of deliver_now for ImportJob mailers, and i…

### DIFF
--- a/app/jobs/nfg_csv_importer/process_import_job.rb
+++ b/app/jobs/nfg_csv_importer/process_import_job.rb
@@ -14,6 +14,7 @@ module NfgCsvImporter
       # both field values will be nil.
       if import.processing? && import.records_processed > import.number_of_records
         import_complete!
+        Rails.logger.info("ProcessImportJob #{import_id}: attempted to begin processing, but import was already completed.")
         return
       end
 
@@ -26,11 +27,14 @@ module NfgCsvImporter
         # the import_service will set this value by default, but we're doing
         # it here for clarity.
         import_service.starting_row = 2
+        Rails.logger.info("ProcessImportJob #{import_id}: beginning to process import" )
       else
         # If this import has a processed_records value, we start processing from
         # the value of that field + 2, which is the next row (taking into account
         # the header row).
-        import_service.starting_row = import.records_processed + 2
+        starting_row = import.records_processed + 2
+        import_service.starting_row = starting_row
+        Rails.logger.info("ProcessImportJob #{import_id}: resuming import from row #{starting_row}")
       end
 
       errors_csv = import_service.import

--- a/app/jobs/nfg_csv_importer/process_import_job.rb
+++ b/app/jobs/nfg_csv_importer/process_import_job.rb
@@ -21,15 +21,16 @@ module NfgCsvImporter
       import_service = import.service
 
       if import.records_processed.blank?
-        NfgCsvImporter::ImportMailer.send_import_result(import).deliver_now
+        NfgCsvImporter::ImportMailer.send_import_result(import).deliver_later
         import.update(processing_started_at: Time.zone.now)
         # the import_service will set this value by default, but we're doing
         # it here for clarity.
         import_service.starting_row = 2
       else
         # If this import has a processed_records value, we start processing from
-        # the value of that field + 1, which is the next row.
-        import_service.starting_row = import.records_processed + 1
+        # the value of that field + 2, which is the next row (taking into account
+        # the header row).
+        import_service.starting_row = import.records_processed + 2
       end
 
       errors_csv = import_service.import
@@ -48,7 +49,7 @@ module NfgCsvImporter
     def import_complete!
       import.complete!
       import.update(processing_finished_at: Time.zone.now)
-      NfgCsvImporter::ImportMailer.send_import_result(import).deliver_now
+      NfgCsvImporter::ImportMailer.send_import_result(import).deliver_later
       Rails.logger.info "ProcessImportJob #{import.id}: completed import"
     end
   end

--- a/spec/jobs/process_import_job_spec.rb
+++ b/spec/jobs/process_import_job_spec.rb
@@ -63,8 +63,8 @@ describe NfgCsvImporter::ProcessImportJob do
       it "should send the mail to admin with imported result" do
         NfgCsvImporter::ImportService.any_instance.stubs(:import).returns(nil)
         # one is expected for processing, and another is for completed
-        NfgCsvImporter::ImportMailer.expects(:send_import_result).with(import).returns(mock("mailer", deliver_now: true))
-        NfgCsvImporter::ImportMailer.expects(:send_import_result).with(import).returns(mock("mailer", deliver_now: true))
+        NfgCsvImporter::ImportMailer.expects(:send_import_result).with(import).returns(mock("mailer", deliver_later: true))
+        NfgCsvImporter::ImportMailer.expects(:send_import_result).with(import).returns(mock("mailer", deliver_later: true))
         subject
       end
     end
@@ -73,7 +73,7 @@ describe NfgCsvImporter::ProcessImportJob do
       before { import.update(records_processed: 3) }
 
       it "does not send the notification email" do
-        NfgCsvImporter::ImportMailer.expects(:send_import_result).with(import).returns(mock("mailer", deliver_now: true))
+        NfgCsvImporter::ImportMailer.expects(:send_import_result).with(import).returns(mock("mailer", deliver_later: true))
         subject
       end
     end
@@ -92,8 +92,8 @@ describe NfgCsvImporter::ProcessImportJob do
 
   it 'enqueues an email' do
     # it is expected twice one for processing, and one for complete
-    NfgCsvImporter::ImportMailer.expects(:send_import_result).returns(mock('import_result', deliver_now: nil))
-    NfgCsvImporter::ImportMailer.expects(:send_import_result).returns(mock('import_result', deliver_now: nil))
+    NfgCsvImporter::ImportMailer.expects(:send_import_result).returns(mock('import_result', deliver_later: nil))
+    NfgCsvImporter::ImportMailer.expects(:send_import_result).returns(mock('import_result', deliver_later: nil))
     subject
   end
 
@@ -112,7 +112,7 @@ describe NfgCsvImporter::ProcessImportJob do
   end
 
   describe "resuming from the last processed row" do
-    before { import.update(records_processed: 2) }
+    before { import.update(records_processed: 1) }
     it 'allows you to restart at the next row' do
       expect { process_import_job.perform(import.id) }.to change { User.count }.by(1)
     end


### PR DESCRIPTION
…ncrement records_processed by 2 when restarting to take into account the header row