### PR TITLE
[#DM-7619] Mark an ImportedRecord as deleted when the associated Importable has already been destroyed

### DIFF
--- a/app/models/nfg_csv_importer/imported_record.rb
+++ b/app/models/nfg_csv_importer/imported_record.rb
@@ -22,7 +22,6 @@ class NfgCsvImporter::ImportedRecord < ActiveRecord::Base
   def destroy_importable!
     self.destroy_stats = {}
 
-    # don't bother doing anything if there's no importable
     if self.importable.present?
       # This is an importable instance method where we can supply criteria
       # to block deletion. The DM user model has this method.
@@ -39,7 +38,12 @@ class NfgCsvImporter::ImportedRecord < ActiveRecord::Base
         # we can delete it.
         destroy_imported_record
       end
+    else
+      # the importable record may have already been manually deleted, in which case we just need to
+      # update this object's state reflect the fact of the deletion; see https://jira.networkforgood.org/browse/DM-7619
+      self.update(deleted: true)
     end
+
     true
   end
 

--- a/spec/models/nfg_csv_importer/imported_record_spec.rb
+++ b/spec/models/nfg_csv_importer/imported_record_spec.rb
@@ -54,9 +54,18 @@ describe NfgCsvImporter::ImportedRecord do
     end
 
     context "when the importable no longer exists" do
-      it "does not raise an exception" do
+      before do
         importable.destroy
+      end
+
+      it "does not raise an exception" do
         expect { imported_record.reload.destroy_importable! }.not_to raise_exception
+      end
+
+      it "sets deleted attribute to 'true'" do
+        # resolves https://jira.networkforgood.org/browse/DM-7619
+        imported_record.reload.destroy_importable!
+        expect(imported_record).to be_deleted
       end
     end
 


### PR DESCRIPTION
this handles a corner case that came up in early December