### PR TITLE
AIO-2736: Alternative to download individual files with ActiveStorage

### DIFF
--- a/app/services/nfg_csv_importer/create_zip_service.rb
+++ b/app/services/nfg_csv_importer/create_zip_service.rb
@@ -31,7 +31,7 @@ module NfgCsvImporter
     private
 
     def store_documents_in_tmp_user_folder(document, tmp_model_folder, filename)
-      download = open(document.service_url)
+      download = StringIO.new(document.download)
       IO.copy_stream(download, "#{tmp_model_folder}/#{filename}")
     end
 

--- a/spec/services/nfg_csv_importer/create_zip_service_spec.rb
+++ b/spec/services/nfg_csv_importer/create_zip_service_spec.rb
@@ -17,12 +17,13 @@ RSpec.describe NfgCsvImporter::CreateZipService do
     context 'when pre_processing_files exist' do
       before do
         NfgCsvImporter::DeleteZipJob.stubs(:perform_in)
-        ActiveStorage::Attachment.any_instance.expects(:service_url).returns('some-url')
+        ActiveStorage::Attachment.any_instance.expects(:download).returns(fake_string_from_file)
         Object.any_instance.expects(:open).returns(File.open("spec/fixtures/individual_donation.csv")).times(3)
       end
 
       let!(:import) { create(:import, :with_pre_processing_files) }
       let(:zip_file) { "#{folder}/#{import.class.name}_#{import.id}.zip" }
+      let(:fake_string_from_file) { File.open("spec/fixtures/individual_donation.csv").read }
 
       it 'creates a zip file' do
         expect{ subject }.to change {


### PR DESCRIPTION
https://networkforgood.atlassian.net/browse/AIO-2736

With these changes the download all files button will be able to be used using an alternative to basically using the method `download` instead generating the signed URL and reading it.

ActiveStorage::Attachment#download

https://github.com/rails/rails/blob/67bc7652fbf7134454acd0c1a02324687102c789/activestorage/app/models/active_storage/blob.rb#L294