### PR TITLE
AIO-2954: Missing index for imported_records table

### DIFF
--- a/db/migrate/20240129183412_add_index_to_imported_record.rb
+++ b/db/migrate/20240129183412_add_index_to_imported_record.rb
@@ -1,0 +1,21 @@
+class AddIndexToImportedRecord < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    # The syntax for concurrently only works in Postgres
+    if ActiveRecord::Base.connection.adapter_name.downcase == "postgresql"
+      add_index(
+        :nfg_csv_importer_imported_records,
+        [:importable_id, :importable_type],
+        algorithm: :concurrently,
+        name: "idx_imported_records_on_importables"
+      )
+    else
+      add_index(
+        :nfg_csv_importer_imported_records,
+        [:importable_id, :importable_type],
+        name: "idx_imported_records_on_importables"
+      )
+    end
+  end
+end

--- a/lib/nfg_csv_importer/version.rb
+++ b/lib/nfg_csv_importer/version.rb
@@ -1,3 +1,3 @@
 module NfgCsvImporter
-  VERSION = "6.1.0.row.length.validation"
+  VERSION = "6.1.0.imported.records.index"
 end

--- a/spec/test_app/db/migrate/20240129183412_add_index_to_imported_record.rb
+++ b/spec/test_app/db/migrate/20240129183412_add_index_to_imported_record.rb
@@ -1,0 +1,21 @@
+class AddIndexToImportedRecord < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    # The syntax for concurrently only works in Postgres
+    if ActiveRecord::Base.connection.adapter_name.downcase == "postgresql"
+      add_index(
+        :nfg_csv_importer_imported_records,
+        [:importable_id, :importable_type],
+        algorithm: :concurrently,
+        name: "idx_imported_records_on_importables"
+      )
+    else
+      add_index(
+        :nfg_csv_importer_imported_records,
+        [:importable_id, :importable_type],
+        name: "idx_imported_records_on_importables"
+      )
+    end
+  end
+end

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_17_152038) do
+ActiveRecord::Schema.define(version: 2024_01_29_183412) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2023_04_17_152038) do
     t.boolean "deleted", default: false
     t.text "row_data"
     t.index ["import_id"], name: "index_nfg_csv_importer_imported_records_on_import_id"
+    t.index ["importable_id", "importable_type"], name: "idx_imported_records_on_importables"
   end
 
   create_table "nfg_csv_importer_imports", force: :cascade do |t|


### PR DESCRIPTION
https://networkforgood.atlassian.net/browse/AIO-2954

This contains a DB migration to add an index for the polymorphic relation on imported_records table.