### PR TITLE
fix(NFG-4074): fix broken import spec and add SQLite WAL files to .gi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ log/*.log
 pkg/
 spec/test_app/db/*.sqlite3
 spec/test_app/db/*.sqlite3-journal
+spec/test_app/db/*.sqlite3-shm
+spec/test_app/db/*.sqlite3-wal
 spec/test_app/log/*.log
 spec/test_app/tmp/
 spec/test_app/.sass-cache

--- a/spec/models/nfg_csv_importer/import_spec.rb
+++ b/spec/models/nfg_csv_importer/import_spec.rb
@@ -143,8 +143,9 @@ describe NfgCsvImporter::Import do
     context 'when the file_origination_type has not been set' do
       let(:file_origination_type_name) { nil }
 
-      it 'should be nil' do
-        expect(subject).to be_nil
+      it 'defaults to the default file origination type' do
+        expect(subject).to be_an_instance_of(NfgCsvImporter::FileOriginationTypes::FileOriginationType)
+        expect(subject.type_sym).to eq(NfgCsvImporter::FileOriginationTypes::Manager::DEFAULT_FILE_ORIGINATION_TYPE_SYM)
       end
     end
 


### PR DESCRIPTION
### Summary

- **Fix broken spec** (`spec/models/nfg_csv_importer/import_spec.rb`): the `file_origination_type` context was asserting `nil` for a persisted record, but the `before_validation :set_default_file_origination_type` callback introduced in #248 always writes the default value on `create`. The spec now asserts the correct default `FileOriginationType` object.
- **Gitignore SQLite WAL files**: `*.sqlite3-shm` and `*.sqlite3-wal` are not covered by the existing `*.sqlite3` pattern (they are distinct file extensions). Added both patterns so they no longer appear as untracked after running the test suite locally.

### Files changed

| File | Change |
|---|---|
| `spec/models/nfg_csv_importer/import_spec.rb` | Update `file_origination_type` assertion to match callback behaviour |
| `.gitignore` | Add `*.sqlite3-shm` and `*.sqlite3-wal` patterns |

### Test plan

```bash
bundle exec rspec spec/models/nfg_csv_importer/import_spec.rb
```

- All import model specs pass ✓
- No SQLite WAL files appear as untracked after the run ✓

### Context

Part of NFG-4070 gem repo standardization epic. CI was failing because the
spec was never updated after the `before_validation` callback was merged in #248.