### PR TITLE
fix(security): SCA upgrades — reform-rails (nfg_csv_importer)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gemspec
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 gem 'nfg_onboarder', git: 'https://github.com/network-for-good/nfg_onboarder.git', branch: 'rails_5'
-gem 'reform-rails', '~> 0.1.7'
+gem 'reform-rails', '0.2.0'
 
 group :development do
   gem 'better_errors' # displays errors in the browser better

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ PATH
       nfg_ui (~> 0.13.0)
       premailer-rails (~> 1.9, >= 1.9.6)
       rails (~> 5.0)
-      reform-rails (~> 0.1.7)
+      reform-rails (= 0.2.0)
       roo (= 2.6.0)
       roo-xls
       rubyzip (~> 1.3.0)
@@ -281,7 +281,7 @@ GEM
     reform (2.2.4)
       disposable (>= 0.4.1)
       representable (>= 2.4.0, < 3.1.0)
-    reform-rails (0.1.7)
+    reform-rails (0.2.0)
       activemodel (>= 3.2)
       reform (>= 2.2.0)
     representable (3.0.4)
@@ -406,7 +406,7 @@ DEPENDENCIES
   pry-byebug
   puma
   rails-controller-testing
-  reform-rails (~> 0.1.7)
+  reform-rails (= 0.2.0)
   rspec-rails (~> 3.5)
   rspec-rails-mocha
   rspec_junit_formatter


### PR DESCRIPTION
## Security: SCA dependency upgrades

Upgrades 1 vulnerable dependency identified via Snyk SCA scanning.

### Changes

| Library | Before | After | CVEs fixed |
|---------|--------|-------|------------|
| reform-rails | 0.1.7 | 0.2.0 | CVE-2026-54904 |

### Linked Jira tickets

- [NFG-4170](https://bonterra.atlassian.net/browse/NFG-4170) — reform-rails upgrade (SLA: 2026-09-06)

### References

- Snyk finding: https://bonterra.atlassian.net/browse/NFG-4170

---
*Opened by Engineering - Application Security. Questions? Reply on this PR or reach out on Slack.*

[NFG-4170]: https://bonterra.atlassian.net/browse/NFG-4170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ